### PR TITLE
feat: Implement full interactivity for timesheet

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,6 +29,22 @@ header nav a:hover {
   text-decoration: underline;
 }
 
+.link-button {
+  background: none;
+  border: none;
+  color: #007bff;
+  text-decoration: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0;
+  margin: 0 10px;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
 /* Main content */
 main {
   text-align: left;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,18 @@ import TimesheetTable from './components/TimesheetTable';
 import Footer from './components/Footer';
 import './App.css';
 
-// Helper function to format date as YYYY-MM-DD
+// --- Sample Data (for initial state) ---
+const initialTasks = [
+  { id: 1, project: 'NR2CTO專案 / EP202507.113 / Jacob Tsai', description: '晨間專案會議', category: 'Project or Taskforce', item: 'Team Meeting or Con-call, Skype', tags: 'Own,A組開發相關' },
+  { id: 2, project: 'NR2CTO專案 / EP202507.113 / Jacob Tsai', description: '公版專案會議', category: 'Project or Taskforce', item: 'Document, Report', tags: '' },
+  { id: 3, project: 'Non-project', description: '休假', category: 'Holiday or Leave', item: 'Personal Leave', tags: '' },
+].map(task => ({
+  ...task,
+  hours: [0, 0, 0, 0, 0, 0, 0], // Mon-Sun
+  isEditing: false,
+}));
+
+// --- Date Helper Functions ---
 const formatDate = (date) => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -12,10 +23,9 @@ const formatDate = (date) => {
   return `${year}-${month}-${day}`;
 };
 
-// Helper function to get the week range string
-const getWeekRange = (date) => {
-  const currentDay = date.getDay(); // Sunday = 0, Monday = 1, etc.
-  const dayOffset = currentDay === 0 ? 6 : currentDay - 1; // Adjust for Sunday
+const getWeekInfo = (date) => {
+  const currentDay = date.getDay();
+  const dayOffset = currentDay === 0 ? 6 : currentDay - 1;
 
   const monday = new Date(date);
   monday.setDate(date.getDate() - dayOffset);
@@ -23,13 +33,30 @@ const getWeekRange = (date) => {
   const sunday = new Date(monday);
   sunday.setDate(monday.getDate() + 6);
 
-  return `${formatDate(monday)} ~ ${formatDate(sunday)}`;
+  return {
+    key: formatDate(monday), // Unique key for the week
+    range: `${formatDate(monday)} ~ ${formatDate(sunday)}`, // Display string
+  };
 };
 
-
+// --- Main App Component ---
 function App() {
   const [currentDate, setCurrentDate] = useState(new Date());
+  const [timesheets, setTimesheets] = useState(() => {
+    // Initialize with the current week's data
+    const initialWeekKey = getWeekInfo(new Date()).key;
+    return {
+      [initialWeekKey]: {
+        tasks: initialTasks,
+        isSubmitted: false,
+      },
+    };
+  });
 
+  const currentWeekInfo = getWeekInfo(currentDate);
+  const currentTimesheet = timesheets[currentWeekInfo.key] || { tasks: [], isSubmitted: false };
+
+  // --- Handlers ---
   const handlePreviousWeek = () => {
     const newDate = new Date(currentDate);
     newDate.setDate(currentDate.getDate() - 7);
@@ -42,18 +69,109 @@ function App() {
     setCurrentDate(newDate);
   };
 
-  const dateRange = getWeekRange(currentDate);
+  const handleCopyLastWeek = () => {
+    const prevWeekDate = new Date(currentDate);
+    prevWeekDate.setDate(currentDate.getDate() - 7);
+    const prevWeekKey = getWeekInfo(prevWeekDate).key;
+
+    const lastWeekTasks = timesheets[prevWeekKey]?.tasks;
+
+    if (lastWeekTasks) {
+      const newTasks = lastWeekTasks.map(task => ({
+        ...task,
+        hours: [0, 0, 0, 0, 0, 0, 0],
+        isEditing: false,
+      }));
+      setTimesheets(prev => ({
+        ...prev,
+        [currentWeekInfo.key]: {
+          ...prev[currentWeekInfo.key],
+          tasks: newTasks,
+        },
+      }));
+    } else {
+      alert("No tasks from last week to copy.");
+    }
+  };
+
+  const handleTaskChange = (taskId, field, value) => {
+    setTimesheets(prev => {
+      const newTasks = prev[currentWeekInfo.key].tasks.map(task =>
+        task.id === taskId ? { ...task, [field]: value } : task
+      );
+      return {
+        ...prev,
+        [currentWeekInfo.key]: { ...prev[currentWeekInfo.key], tasks: newTasks },
+      };
+    });
+  };
+
+  const handleHoursChange = (taskId, dayIndex, value) => {
+    const hours = parseInt(value, 10) || 0; // Ensure value is a number
+    setTimesheets(prev => {
+      const newTasks = prev[currentWeekInfo.key].tasks.map(task => {
+        if (task.id === taskId) {
+          const newHours = [...task.hours];
+          newHours[dayIndex] = hours;
+          return { ...task, hours: newHours };
+        }
+        return task;
+      });
+      return {
+        ...prev,
+        [currentWeekInfo.key]: { ...prev[currentWeekInfo.key], tasks: newTasks },
+      };
+    });
+  };
+
+  const handleSubmit = () => {
+    const tasks = currentTimesheet.tasks;
+    const dailyTotals = Array(5).fill(0); // Monday to Friday
+
+    tasks.forEach(task => {
+      for (let i = 0; i < 5; i++) { // Only check Mon-Fri
+        dailyTotals[i] += task.hours[i] || 0;
+      }
+    });
+
+    const invalidDays = dailyTotals.map((total, i) => total !== 8 ? i + 1 : -1).filter(day => day !== -1);
+
+    if (invalidDays.length > 0) {
+      alert(`Validation failed! Total hours for Monday-Friday must be 8. Please check day(s): ${invalidDays.join(', ')}.`);
+      return;
+    }
+
+    setTimesheets(prev => ({
+      ...prev,
+      [currentWeekInfo.key]: {
+        ...prev[currentWeekInfo.key],
+        isSubmitted: true,
+      },
+    }));
+
+    alert('Timesheet submitted successfully!');
+  };
 
   return (
     <div className="App">
-      <Header />
+      <Header
+        onCopyLastWeek={handleCopyLastWeek}
+        isSubmitted={currentTimesheet.isSubmitted}
+      />
       <main>
-        <TimesheetTable />
+        <TimesheetTable
+          tasks={currentTimesheet.tasks}
+          isSubmitted={currentTimesheet.isSubmitted}
+          onTaskChange={handleTaskChange}
+          onHoursChange={handleHoursChange}
+        />
       </main>
       <Footer
-        dateRange={dateRange}
+        dateRange={currentWeekInfo.range}
         onPrevWeek={handlePreviousWeek}
         onNextWeek={handleNextWeek}
+        onSubmit={handleSubmit}
+        isSubmitted={currentTimesheet.isSubmitted}
       />
     </div>
   );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 
-function Footer({ dateRange, onPrevWeek, onNextWeek }) {
+function Footer({ dateRange, onPrevWeek, onNextWeek, onSubmit, isSubmitted }) {
   return (
     <footer>
       <div className="date-navigation">
-        <button onClick={onPrevWeek}>&lt;&lt;</button>
+        <button onClick={onPrevWeek} disabled={isSubmitted}>&lt;&lt;</button>
         <span>{dateRange}</span>
         <a href="#">(This Week)</a>
-        <button onClick={onNextWeek}>&gt;&gt;</button>
+        <button onClick={onNextWeek} disabled={isSubmitted}>&gt;&gt;</button>
       </div>
       <div className="submit-section">
-        <button>Submit to Boss</button>
+        <button onClick={onSubmit} disabled={isSubmitted}>Submit to Boss</button>
       </div>
     </footer>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 
-function Header() {
+function Header({ onCopyLastWeek, isSubmitted }) {
   return (
     <header>
       <h1>我的工作日誌</h1>
       <nav>
         <a href="#">新增工作</a>
-        <a href="#">複製上週工作</a>
+        <button
+          onClick={onCopyLastWeek}
+          className="link-button"
+          disabled={isSubmitted}
+        >
+          複製上週工作
+        </button>
         <a href="#">每週回報</a>
         <a href="#">TSS App v2.00</a>
         <a href="#">工時查詢與技巧</a>

--- a/src/components/TimesheetTable.jsx
+++ b/src/components/TimesheetTable.jsx
@@ -1,83 +1,13 @@
 import React from 'react';
 
-const sampleTasks = [
-  {
-    id: 1,
-    project: 'NR2CTO專案 / EP202507.113 / Jacob Tsai',
-    description: '晨間專案會議',
-    category: 'Project or Taskforce',
-    item: 'Team Meeting or Con-call, Skype',
-    tags: 'Own,A組開發相關',
-  },
-  {
-    id: 2,
-    project: 'NR2CTO專案 / EP202507.113 / Jacob Tsai',
-    description: '公版專案會議',
-    category: 'Project or Taskforce',
-    item: 'Document, Report',
-    tags: '',
-  },
-  {
-    id: 3,
-    project: 'NR2CTO專案 / EP202507.113 / Jacob Tsai',
-    description: '公版專案需求處理',
-    category: 'Project or Taskforce',
-    item: 'Action or Issue Tracking',
-    tags: '',
-  },
-  {
-    id: 4,
-    project: 'NR2CTO專案 / EP202507.113 / Jacob Tsai',
-    description: 'AI雲專案文件處理',
-    category: 'Project or Taskforce',
-    item: 'Document, Report',
-    tags: 'Own,A組開發相關',
-  },
-  {
-    id: 5,
-    project: 'NR2CTO專案 / EP202507.113 / Jacob Tsai',
-    description: '晨間專案文件處理',
-    category: 'Project or Taskforce',
-    item: 'Document, Report',
-    tags: 'Own,A組開發相關',
-  },
-  {
-    id: 6,
-    project: 'NR2CTO專案 / EP202507.113 / Jacob Tsai',
-    description: '公版專案專案文件',
-    category: 'Project or Taskforce',
-    item: 'Document, Report',
-    tags: '',
-  },
-  {
-    id: 7,
-    project: 'Non-project',
-    description: '休假',
-    category: 'Holiday or Leave',
-    item: 'Personal Leave',
-    tags: '',
-  },
-  {
-    id: 8,
-    project: 'Non-project',
-    description: '假日',
-    category: 'Holiday or Leave',
-    item: 'Holiday',
-    tags: '',
-  },
-  {
-    id: 9,
-    project: 'Non-project',
-    description: '新技術或專案研究',
-    category: 'Department Activity',
-    item: 'Research, Survey',
-    tags: '',
-  },
-];
-
 const days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 
-function TimesheetTable() {
+function TimesheetTable({ tasks, isSubmitted, onTaskChange, onHoursChange }) {
+
+  const dailyTotals = days.map((_, dayIndex) =>
+    tasks.reduce((total, task) => total + (task.hours[dayIndex] || 0), 0)
+  );
+
   return (
     <table>
       <thead>
@@ -92,20 +22,43 @@ function TimesheetTable() {
         </tr>
       </thead>
       <tbody>
-        {sampleTasks.map(task => (
+        {tasks.map(task => (
           <tr key={task.id}>
             <td>
-              <button>✏️</button>
-              <button>❌</button>
+              <button
+                onClick={() => onTaskChange(task.id, 'isEditing', !task.isEditing)}
+                disabled={isSubmitted}
+              >
+                ✏️
+              </button>
+              <button disabled={isSubmitted}>❌</button>
             </td>
-            <td>{task.project}</td>
+            <td>
+              {task.isEditing ? (
+                <input
+                  type="text"
+                  value={task.project}
+                  onChange={(e) => onTaskChange(task.id, 'project', e.target.value)}
+                  disabled={isSubmitted}
+                  style={{ width: '100%' }}
+                />
+              ) : (
+                task.project
+              )}
+            </td>
             <td>{task.description}</td>
             <td>{task.category}</td>
             <td>{task.item}</td>
             <td>{task.tags}</td>
-            {days.map(day => (
+            {days.map((day, dayIndex) => (
               <td key={day}>
-                <input type="text" size="3" />
+                <input
+                  type="text"
+                  size="3"
+                  value={task.hours[dayIndex]}
+                  onChange={(e) => onHoursChange(task.id, dayIndex, e.target.value)}
+                  disabled={isSubmitted}
+                />
               </td>
             ))}
           </tr>
@@ -114,11 +67,11 @@ function TimesheetTable() {
       <tfoot>
         <tr>
           <td colSpan="6">工作時數</td>
-          {days.map(day => <td key={day}></td>)}
+          {dailyTotals.map((total, index) => <td key={index}>{total}</td>)}
         </tr>
         <tr>
           <td colSpan="6">打卡時數</td>
-          {days.map(day => <td key={day}></td>)}
+          {days.map((day, index) => <td key={index}></td>)}
         </tr>
       </tfoot>
     </table>


### PR DESCRIPTION
This commit adds a comprehensive set of interactive features to the timesheet application, transforming it from a static UI into a functional tool.

- Refactors state management to handle timesheets on a per-week basis.
- Implements inline editing for project names and controlled inputs for hours.
- Adds a "Copy Last Week's Tasks" button to carry over projects.
- Implements the "Submit to Boss" functionality, which includes validation to ensure Mon-Fri daily hours sum to 8.
- Adds a UI locking mechanism to prevent edits to a timesheet after it has been submitted.